### PR TITLE
Integrate official DevToDev SDKs

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -82,7 +82,6 @@ dependencies {
     // AppsFlyer Purchase Connector для IAP валидации
     implementation("com.appsflyer:purchase-connector:2.1.1")
 
-    // DevToDev Analytics SDK v2
-    implementation("com.devtodev:android-analytics:2.5.1")
-    implementation("com.devtodev:android-google:1.0.1")
+    // DevToDev official Analytics SDK
+    implementation("com.devtodev.analytics:analytics:3.0.0")
 }

--- a/android/app/src/main/kotlin/com/playcus/hydracoach/DevToDevMethodHandler.kt
+++ b/android/app/src/main/kotlin/com/playcus/hydracoach/DevToDevMethodHandler.kt
@@ -4,99 +4,27 @@ import android.content.Context
 import android.util.Log
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
+import java.lang.reflect.Modifier
 import org.json.JSONObject
 
 class DevToDevMethodHandler(private val context: Context) {
     private val TAG = "DevToDevMethodHandler"
     private var isInitialized = false
 
+    private val classCandidates = listOf(
+        "com.devtodev.analytics.DevToDev",
+        "com.devtodev.analytics.Analytics",
+        "com.devtodev.analytics.analytics.DevToDev",
+        "com.devtodev.analytics.analytics.Analytics",
+        "com.devtodev.analytics.DTDAnalytics"
+    )
+
     fun handle(call: MethodCall, result: MethodChannel.Result) {
         try {
             when (call.method) {
-                "initialize" -> {
-                    val appId = call.argument<String>("appId") ?: ""
-                    val secretKey = call.argument<String>("secretKey") ?: ""
-                    val apiKey = call.argument<String>("apiKey") ?: ""
-
-                    Log.d(TAG, "Initializing DevToDev with appId: $appId")
-
-                    // Use reflection to call DevToDev.initialize
-                    try {
-                        val dtdClass = Class.forName("com.devtodev.analytics.DTDAnalytics")
-                        val initMethod = dtdClass.getDeclaredMethod("initialize", String::class.java, Context::class.java)
-                        initMethod.invoke(null, appId, context)
-
-                        isInitialized = true
-                        Log.d(TAG, "DevToDev initialized successfully via reflection")
-                        result.success(null)
-                    } catch (e: Exception) {
-                        Log.w(TAG, "Failed to initialize via first method, trying alternative: ${e.message}")
-
-                        // Try alternative initialization method
-                        try {
-                            val dtdClass = Class.forName("com.devtodev.analytics.DTDAnalytics")
-                            val instanceField = dtdClass.getDeclaredField("INSTANCE")
-                            val instance = instanceField.get(null)
-
-                            val initMethod = dtdClass.getDeclaredMethod("initialize", String::class.java, Context::class.java)
-                            initMethod.invoke(instance, appId, context)
-
-                            isInitialized = true
-                            Log.d(TAG, "DevToDev initialized successfully via INSTANCE")
-                            result.success(null)
-                        } catch (e2: Exception) {
-                            Log.e(TAG, "Failed to initialize DevToDev via reflection: ${e2.message}")
-                            // Still return success to avoid blocking Flutter
-                            result.success(null)
-                        }
-                    }
-                }
-
-                "logEvent" -> {
-                    val eventName = call.argument<String>("name") ?: ""
-                    val parameters = call.argument<Map<String, Any>>("parameters") ?: emptyMap()
-
-                    Log.d(TAG, "Logging event: $eventName with params: $parameters")
-
-                    try {
-                        val dtdClass = Class.forName("com.devtodev.analytics.DTDAnalytics")
-
-                        if (parameters.isEmpty()) {
-                            val customEventMethod = dtdClass.getDeclaredMethod("customEvent", String::class.java)
-                            customEventMethod.invoke(null, eventName)
-                        } else {
-                            val jsonParams = JSONObject(parameters)
-                            val customEventMethod = dtdClass.getDeclaredMethod("customEvent", String::class.java, JSONObject::class.java)
-                            customEventMethod.invoke(null, eventName, jsonParams)
-                        }
-
-                        Log.d(TAG, "Event logged successfully")
-                        result.success(null)
-                    } catch (e: Exception) {
-                        Log.w(TAG, "Failed to log event via reflection: ${e.message}")
-                        // Still return success to avoid blocking Flutter
-                        result.success(null)
-                    }
-                }
-
-                "setUserId" -> {
-                    val userId = call.argument<String>("userId") ?: ""
-                    Log.d(TAG, "Setting user ID: $userId")
-
-                    try {
-                        val dtdClass = Class.forName("com.devtodev.analytics.DTDAnalytics")
-                        val setUserIdMethod = dtdClass.getDeclaredMethod("setUserId", String::class.java)
-                        setUserIdMethod.invoke(null, userId)
-
-                        Log.d(TAG, "User ID set successfully")
-                        result.success(null)
-                    } catch (e: Exception) {
-                        Log.w(TAG, "Failed to set user ID via reflection: ${e.message}")
-                        // Still return success to avoid blocking Flutter
-                        result.success(null)
-                    }
-                }
-
+                "initialize" -> handleInitialize(call, result)
+                "logEvent" -> handleLogEvent(call, result)
+                "setUserId" -> handleSetUserId(call, result)
                 else -> {
                     Log.w(TAG, "Unknown method: ${call.method}")
                     result.notImplemented()
@@ -106,5 +34,311 @@ class DevToDevMethodHandler(private val context: Context) {
             Log.e(TAG, "Error handling method ${call.method}: ${e.message}", e)
             result.error("DEVTODEV_ERROR", "Error: ${e.message}", null)
         }
+    }
+
+    private fun handleInitialize(call: MethodCall, result: MethodChannel.Result) {
+        val appId = call.argument<String>("appId") ?: ""
+        val secretKey = call.argument<String>("secretKey") ?: ""
+        val apiKey = call.argument<String>("apiKey") ?: ""
+
+        Log.d(TAG, "Initializing DevToDev with appId: $appId")
+
+        val clazz = resolveDevToDevClass()
+        if (clazz == null) {
+            Log.e(TAG, "DevToDev class not found in runtime classpath")
+            result.error("DEVTODEV_UNAVAILABLE", "DevToDev SDK is not linked", null)
+            return
+        }
+
+        val initializationSucceeded = tryInitialize(clazz, appId, secretKey, apiKey)
+        if (initializationSucceeded) {
+            isInitialized = true
+            Log.d(TAG, "DevToDev initialized successfully")
+            result.success(null)
+        } else {
+            Log.e(TAG, "DevToDev initialization failed for all known signatures")
+            result.error("DEVTODEV_UNAVAILABLE", "Failed to initialize DevToDev", null)
+        }
+    }
+
+    private fun handleLogEvent(call: MethodCall, result: MethodChannel.Result) {
+        val eventName = call.argument<String>("name") ?: ""
+        val parameters = call.argument<Map<String, Any>>("parameters") ?: emptyMap()
+
+        if (!isInitialized) {
+            Log.w(TAG, "DevToDev is not initialized. Skipping event: $eventName")
+            result.error("DEVTODEV_UNAVAILABLE", "DevToDev is not initialized", null)
+            return
+        }
+
+        val clazz = resolveDevToDevClass()
+        if (clazz == null) {
+            Log.e(TAG, "DevToDev class not found when logging event")
+            result.error("DEVTODEV_UNAVAILABLE", "DevToDev SDK is not linked", null)
+            return
+        }
+
+        val success = tryLogEvent(clazz, eventName, parameters)
+        if (success) {
+            Log.d(TAG, "Event $eventName logged successfully")
+            result.success(null)
+        } else {
+            Log.e(TAG, "Failed to log event $eventName")
+            result.error("DEVTODEV_UNAVAILABLE", "Failed to log event", null)
+        }
+    }
+
+    private fun handleSetUserId(call: MethodCall, result: MethodChannel.Result) {
+        val userId = call.argument<String>("userId") ?: ""
+
+        if (!isInitialized) {
+            Log.w(TAG, "DevToDev is not initialized. Skipping user id update")
+            result.error("DEVTODEV_UNAVAILABLE", "DevToDev is not initialized", null)
+            return
+        }
+
+        val clazz = resolveDevToDevClass()
+        if (clazz == null) {
+            Log.e(TAG, "DevToDev class not found when setting user id")
+            result.error("DEVTODEV_UNAVAILABLE", "DevToDev SDK is not linked", null)
+            return
+        }
+
+        val success = trySetUserId(clazz, userId)
+        if (success) {
+            Log.d(TAG, "User ID set successfully")
+            result.success(null)
+        } else {
+            Log.e(TAG, "Failed to set user id")
+            result.error("DEVTODEV_UNAVAILABLE", "Failed to set user id", null)
+        }
+    }
+
+    private fun resolveDevToDevClass(): Class<*>? {
+        classCandidates.forEach { candidate ->
+            try {
+                return Class.forName(candidate)
+            } catch (_: ClassNotFoundException) {
+                // Try next candidate.
+            }
+        }
+        return null
+    }
+
+    private fun tryInitialize(clazz: Class<*>, appId: String, secretKey: String, apiKey: String): Boolean {
+        val signatures = listOf(
+            MethodSignature(
+                "initialize",
+                arrayOf(Context::class.java, String::class.java, String::class.java, String::class.java),
+                receiverProvider = { null }
+            ) {
+                arrayOf<Any>(context, appId, secretKey, apiKey)
+            },
+            MethodSignature(
+                "initialize",
+                arrayOf(String::class.java, String::class.java, String::class.java, Context::class.java),
+                receiverProvider = { null }
+            ) {
+                arrayOf<Any>(appId, secretKey, apiKey, context)
+            },
+            MethodSignature(
+                "initialize",
+                arrayOf(String::class.java, Context::class.java),
+                receiverProvider = { null }
+            ) {
+                arrayOf<Any>(appId, context)
+            },
+            MethodSignature(
+                "initialize",
+                arrayOf(Context::class.java, String::class.java),
+                receiverProvider = { null }
+            ) {
+                arrayOf<Any>(context, appId)
+            },
+            MethodSignature(
+                "activate",
+                arrayOf(Context::class.java, String::class.java, String::class.java, String::class.java),
+                receiverProvider = { null }
+            ) {
+                arrayOf<Any>(context, appId, secretKey, apiKey)
+            },
+            MethodSignature(
+                "initialize",
+                arrayOf(Context::class.java, String::class.java, String::class.java, String::class.java),
+                receiverProvider = { resolveInstance(it) }
+            ) {
+                arrayOf<Any>(context, appId, secretKey, apiKey)
+            },
+            MethodSignature(
+                "initialize",
+                arrayOf(String::class.java, String::class.java, String::class.java, Context::class.java),
+                receiverProvider = { resolveInstance(it) }
+            ) {
+                arrayOf<Any>(appId, secretKey, apiKey, context)
+            },
+            MethodSignature(
+                "activate",
+                arrayOf(Context::class.java, String::class.java, String::class.java, String::class.java),
+                receiverProvider = { resolveInstance(it) }
+            ) {
+                arrayOf<Any>(context, appId, secretKey, apiKey)
+            }
+        )
+
+        return invokeFirstSuccessful(clazz, signatures)
+    }
+
+    private fun tryLogEvent(clazz: Class<*>, eventName: String, parameters: Map<String, Any>): Boolean {
+        val jsonParams = JSONObject(parameters)
+        val signatures = listOf(
+            MethodSignature(
+                "customEvent",
+                arrayOf(String::class.java),
+                receiverProvider = { null }
+            ) {
+                arrayOf<Any>(eventName)
+            },
+            MethodSignature(
+                "customEvent",
+                arrayOf(String::class.java, JSONObject::class.java),
+                receiverProvider = { null }
+            ) {
+                arrayOf<Any>(eventName, jsonParams)
+            },
+            MethodSignature(
+                "logEvent",
+                arrayOf(String::class.java, JSONObject::class.java),
+                receiverProvider = { null }
+            ) {
+                arrayOf<Any>(eventName, jsonParams)
+            },
+            MethodSignature(
+                "event",
+                arrayOf(String::class.java, JSONObject::class.java),
+                receiverProvider = { null }
+            ) {
+                arrayOf<Any>(eventName, jsonParams)
+            },
+            MethodSignature(
+                "customEvent",
+                arrayOf(String::class.java),
+                receiverProvider = { resolveInstance(it) }
+            ) {
+                arrayOf<Any>(eventName)
+            },
+            MethodSignature(
+                "customEvent",
+                arrayOf(String::class.java, JSONObject::class.java),
+                receiverProvider = { resolveInstance(it) }
+            ) {
+                arrayOf<Any>(eventName, jsonParams)
+            },
+            MethodSignature(
+                "logEvent",
+                arrayOf(String::class.java, JSONObject::class.java),
+                receiverProvider = { resolveInstance(it) }
+            ) {
+                arrayOf<Any>(eventName, jsonParams)
+            },
+            MethodSignature(
+                "event",
+                arrayOf(String::class.java, JSONObject::class.java),
+                receiverProvider = { resolveInstance(it) }
+            ) {
+                arrayOf<Any>(eventName, jsonParams)
+            }
+        )
+
+        return invokeFirstSuccessful(clazz, signatures)
+    }
+
+    private fun trySetUserId(clazz: Class<*>, userId: String): Boolean {
+        val signatures = listOf(
+            MethodSignature(
+                "setUserId",
+                arrayOf(String::class.java),
+                receiverProvider = { null }
+            ) {
+                arrayOf<Any>(userId)
+            },
+            MethodSignature(
+                "setUserId",
+                arrayOf(Context::class.java, String::class.java),
+                receiverProvider = { null }
+            ) {
+                arrayOf<Any>(context, userId)
+            },
+            MethodSignature(
+                "setUserId",
+                arrayOf(String::class.java),
+                receiverProvider = { resolveInstance(it) }
+            ) {
+                arrayOf<Any>(userId)
+            },
+            MethodSignature(
+                "setUserId",
+                arrayOf(Context::class.java, String::class.java),
+                receiverProvider = { resolveInstance(it) }
+            ) {
+                arrayOf<Any>(context, userId)
+            }
+        )
+
+        return invokeFirstSuccessful(clazz, signatures)
+    }
+
+    private fun invokeFirstSuccessful(clazz: Class<*>, signatures: List<MethodSignature>): Boolean {
+        signatures.forEach { signature ->
+            try {
+                val method = clazz.getDeclaredMethod(signature.methodName, *signature.parameterTypes)
+                method.isAccessible = true
+                val receiver = if (Modifier.isStatic(method.modifiers)) {
+                    null
+                } else {
+                    signature.receiverProvider.invoke(clazz) ?: return@forEach
+                }
+                method.invoke(receiver, *signature.argumentsProvider.invoke())
+                return true
+            } catch (ignored: Exception) {
+                // Try next signature.
+            }
+        }
+        return false
+    }
+
+    private data class MethodSignature(
+        val methodName: String,
+        val parameterTypes: Array<Class<*>>,
+        val receiverProvider: (Class<*>) -> Any?,
+        val argumentsProvider: () -> Array<Any>
+    )
+
+    private fun resolveInstance(clazz: Class<*>): Any? {
+        val instanceFields = listOf("INSTANCE", "instance")
+        instanceFields.forEach { fieldName ->
+            try {
+                val field = clazz.getDeclaredField(fieldName)
+                field.isAccessible = true
+                val instance = field.get(null)
+                if (instance != null) {
+                    return instance
+                }
+            } catch (_: Exception) {
+                // Ignore and try other resolution strategies.
+            }
+        }
+
+        val factoryMethods = listOf("getInstance", "instance", "shared", "sharedInstance")
+        factoryMethods.forEach { methodName ->
+            try {
+                val method = clazz.getDeclaredMethod(methodName)
+                method.isAccessible = true
+                return method.invoke(null)
+            } catch (_: Exception) {
+                // Ignore and try next
+            }
+        }
+
+        return null
     }
 }

--- a/android/app/src/main/kotlin/com/playcus/hydracoach/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/playcus/hydracoach/MainActivity.kt
@@ -5,7 +5,6 @@ import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodChannel
 import android.util.Log
 // DevToDev integration via reflection-based handler
-import org.json.JSONObject
 
 class MainActivity: FlutterActivity() {
     private val CHANNEL = "hydracoach.purchase_connector"

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -3,6 +3,9 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+        maven {
+            url = uri("https://maven.devtodev.com/public")
+        }
     }
     dependencies {
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
@@ -17,6 +20,9 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+        maven {
+            url = uri("https://maven.devtodev.com/public")
+        }
     }
 }
 

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -35,6 +35,8 @@ target 'Runner' do
 
   # AppsFlyer Purchase Connector для IAP валидации
   pod 'PurchaseConnector', '~> 2.1.1'
+  # DevToDev official Analytics SDK
+  pod 'DevToDevSDK', '~> 3.0'
 end
 
 post_install do |installer|

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1,4 +1,5 @@
 import Flutter
+import ObjectiveC.runtime
 import UIKit
 
 @main
@@ -18,6 +19,8 @@ import UIKit
       name: "devtodev_analytics",
       binaryMessenger: controller.binaryMessenger
     )
+
+    let devToDevBridge = DevToDevBridge()
 
     purchaseConnectorChannel.setMethodCallHandler { [weak self] (call, result) in
       switch call.method {
@@ -41,35 +44,54 @@ import UIKit
     devToDevChannel.setMethodCallHandler { [weak self] (call, result) in
       switch call.method {
       case "initialize":
-        // DevToDev iOS integration - TODO: Add native DevToDev iOS SDK
-        if let args = call.arguments as? [String: Any],
-           let appId = args["appId"] as? String {
-          print("DevToDev iOS: Initialize called with appId: \(appId)")
-          // TODO: Call DevToDev iOS SDK initialization
+        guard
+          let args = call.arguments as? [String: Any],
+          let appId = args["appId"] as? String,
+          let secretKey = args["secretKey"] as? String,
+          let apiKey = args["apiKey"] as? String
+        else {
+          result(FlutterError(code: "INVALID_ARGS", message: "Missing DevToDev credentials", details: nil))
+          return
+        }
+
+        switch devToDevBridge.initialize(appId: appId, secretKey: secretKey, apiKey: apiKey) {
+        case .success:
           result(nil)
-        } else {
-          result(FlutterError(code: "INVALID_ARGS", message: "Missing appId", details: nil))
+        case .failure(let error):
+          result(error)
         }
 
       case "logEvent":
-        if let args = call.arguments as? [String: Any],
-           let eventName = args["name"] as? String {
-          let parameters = args["parameters"] as? [String: Any] ?? [:]
-          print("DevToDev iOS: Event \(eventName) with params: \(parameters)")
-          // TODO: Call DevToDev iOS SDK logEvent
-          result(nil)
-        } else {
+        guard
+          let args = call.arguments as? [String: Any],
+          let eventName = args["name"] as? String
+        else {
           result(FlutterError(code: "INVALID_ARGS", message: "Missing event name", details: nil))
+          return
+        }
+
+        let parameters = args["parameters"] as? [String: Any] ?? [:]
+        switch devToDevBridge.logEvent(name: eventName, parameters: parameters) {
+        case .success:
+          result(nil)
+        case .failure(let error):
+          result(error)
         }
 
       case "setUserId":
-        if let args = call.arguments as? [String: Any],
-           let userId = args["userId"] as? String {
-          print("DevToDev iOS: Setting userId: \(userId)")
-          // TODO: Call DevToDev iOS SDK setUserId
-          result(nil)
-        } else {
+        guard
+          let args = call.arguments as? [String: Any],
+          let userId = args["userId"] as? String
+        else {
           result(FlutterError(code: "INVALID_ARGS", message: "Missing userId", details: nil))
+          return
+        }
+
+        switch devToDevBridge.setUserId(userId) {
+        case .success:
+          result(nil)
+        case .failure(let error):
+          result(error)
         }
 
       default:
@@ -79,5 +101,243 @@ import UIKit
 
     GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+}
+
+private final class DevToDevBridge {
+  fileprivate enum BridgeResult {
+    case success
+    case failure(FlutterError)
+  }
+
+  private let classCandidates = [
+    "DevToDev",
+    "DevToDevSDK.DevToDev"
+  ]
+
+  private var sdkClass: AnyClass?
+  private var sdkInstance: AnyObject?
+  private var isInitialized = false
+
+  init() {
+    sdkClass = Self.resolveDevToDevClass(from: classCandidates)
+  }
+
+  func initialize(appId: String, secretKey: String, apiKey: String) -> BridgeResult {
+    guard let sdkClass else {
+      return .failure(FlutterError(code: "DEVTODEV_UNAVAILABLE", message: "DevToDev SDK not linked", details: nil))
+    }
+
+    if isInitialized {
+      return .success
+    }
+
+    let metaClass = object_getClass(sdkClass)
+    let credentials = (appId as NSString, secretKey as NSString, apiKey as NSString)
+
+    let classInitializationSelectors: [(String, (IMP, Selector) -> Void)] = [
+      ("activateWithAppID:secretKey:apiKey:", { imp, selector in
+        typealias Function = @convention(c) (AnyObject, Selector, NSString, NSString, NSString) -> Void
+        let function = unsafeBitCast(imp, to: Function.self)
+        function(sdkClass, selector, credentials.0, credentials.1, credentials.2)
+      }),
+      ("activateWithAppId:secretKey:apiKey:", { imp, selector in
+        typealias Function = @convention(c) (AnyObject, Selector, NSString, NSString, NSString) -> Void
+        let function = unsafeBitCast(imp, to: Function.self)
+        function(sdkClass, selector, credentials.0, credentials.1, credentials.2)
+      }),
+      ("activateWithAppID:secretKey:", { imp, selector in
+        typealias Function = @convention(c) (AnyObject, Selector, NSString, NSString) -> Void
+        let function = unsafeBitCast(imp, to: Function.self)
+        function(sdkClass, selector, credentials.0, credentials.1)
+      }),
+      ("initializeWithAppId:secretKey:apiKey:", { imp, selector in
+        typealias Function = @convention(c) (AnyObject, Selector, NSString, NSString, NSString) -> Void
+        let function = unsafeBitCast(imp, to: Function.self)
+        function(sdkClass, selector, credentials.0, credentials.1, credentials.2)
+      }),
+      ("initializeWithAppId:secretKey:", { imp, selector in
+        typealias Function = @convention(c) (AnyObject, Selector, NSString, NSString) -> Void
+        let function = unsafeBitCast(imp, to: Function.self)
+        function(sdkClass, selector, credentials.0, credentials.1)
+      })
+    ]
+
+    if Self.invokeClassMethod(metaClass, target: sdkClass, candidates: classInitializationSelectors) {
+      isInitialized = true
+      return .success
+    }
+
+    guard let instance = resolveInstance(from: sdkClass) else {
+      return .failure(FlutterError(code: "DEVTODEV_UNAVAILABLE", message: "Unable to initialize DevToDev", details: nil))
+    }
+
+    let instanceSelectors: [(String, (IMP, Selector) -> Void)] = [
+      ("activateWithAppID:secretKey:apiKey:", { imp, selector in
+        typealias Function = @convention(c) (AnyObject, Selector, NSString, NSString, NSString) -> Void
+        let function = unsafeBitCast(imp, to: Function.self)
+        function(instance, selector, credentials.0, credentials.1, credentials.2)
+      }),
+      ("activateWithAppID:secretKey:", { imp, selector in
+        typealias Function = @convention(c) (AnyObject, Selector, NSString, NSString) -> Void
+        let function = unsafeBitCast(imp, to: Function.self)
+        function(instance, selector, credentials.0, credentials.1)
+      }),
+      ("initializeWithAppId:secretKey:apiKey:", { imp, selector in
+        typealias Function = @convention(c) (AnyObject, Selector, NSString, NSString, NSString) -> Void
+        let function = unsafeBitCast(imp, to: Function.self)
+        function(instance, selector, credentials.0, credentials.1, credentials.2)
+      }),
+      ("initializeWithAppId:secretKey:", { imp, selector in
+        typealias Function = @convention(c) (AnyObject, Selector, NSString, NSString) -> Void
+        let function = unsafeBitCast(imp, to: Function.self)
+        function(instance, selector, credentials.0, credentials.1)
+      })
+    ]
+
+    if Self.invokeInstanceMethod(instance, candidates: instanceSelectors) {
+      sdkInstance = instance
+      isInitialized = true
+      return .success
+    }
+
+    return .failure(FlutterError(code: "DEVTODEV_UNAVAILABLE", message: "Unable to initialize DevToDev", details: nil))
+  }
+
+  func logEvent(name: String, parameters: [String: Any]) -> BridgeResult {
+    guard let target = resolvedTarget() else {
+      return .failure(FlutterError(code: "DEVTODEV_UNAVAILABLE", message: "DevToDev is not initialized", details: nil))
+    }
+
+    let eventName = name as NSString
+    let params = parameters as NSDictionary
+
+    let selectors: [(String, (IMP, Selector) -> Void)] = [
+      ("customEventWithName:params:", { imp, selector in
+        typealias Function = @convention(c) (AnyObject, Selector, NSString, NSDictionary) -> Void
+        let function = unsafeBitCast(imp, to: Function.self)
+        function(target, selector, eventName, params)
+      }),
+      ("customEvent:params:", { imp, selector in
+        typealias Function = @convention(c) (AnyObject, Selector, NSString, NSDictionary) -> Void
+        let function = unsafeBitCast(imp, to: Function.self)
+        function(target, selector, eventName, params)
+      }),
+      ("customEvent:", { imp, selector in
+        typealias Function = @convention(c) (AnyObject, Selector, NSString) -> Void
+        let function = unsafeBitCast(imp, to: Function.self)
+        function(target, selector, eventName)
+      }),
+      ("logEventWithName:parameters:", { imp, selector in
+        typealias Function = @convention(c) (AnyObject, Selector, NSString, NSDictionary) -> Void
+        let function = unsafeBitCast(imp, to: Function.self)
+        function(target, selector, eventName, params)
+      })
+    ]
+
+    if Self.invoke(target: target, candidates: selectors) {
+      return .success
+    }
+
+    return .failure(FlutterError(code: "DEVTODEV_UNAVAILABLE", message: "Unable to log DevToDev event", details: nil))
+  }
+
+  func setUserId(_ userId: String) -> BridgeResult {
+    guard let target = resolvedTarget() else {
+      return .failure(FlutterError(code: "DEVTODEV_UNAVAILABLE", message: "DevToDev is not initialized", details: nil))
+    }
+
+    let selectors: [(String, (IMP, Selector) -> Void)] = [
+      ("setUserId:", { imp, selector in
+        typealias Function = @convention(c) (AnyObject, Selector, NSString) -> Void
+        let function = unsafeBitCast(imp, to: Function.self)
+        function(target, selector, userId as NSString)
+      }),
+      ("setUserID:", { imp, selector in
+        typealias Function = @convention(c) (AnyObject, Selector, NSString) -> Void
+        let function = unsafeBitCast(imp, to: Function.self)
+        function(target, selector, userId as NSString)
+      })
+    ]
+
+    if Self.invoke(target: target, candidates: selectors) {
+      return .success
+    }
+
+    return .failure(FlutterError(code: "DEVTODEV_UNAVAILABLE", message: "Unable to set DevToDev userId", details: nil))
+  }
+
+  private func resolvedTarget() -> AnyObject? {
+    if let sdkInstance {
+      return sdkInstance
+    }
+
+    guard let sdkClass else {
+      return nil
+    }
+
+    if let instance = resolveInstance(from: sdkClass) {
+      sdkInstance = instance
+      return instance
+    }
+
+    return sdkClass
+  }
+
+  private func resolveInstance(from clazz: AnyClass) -> AnyObject? {
+    let metaClass = object_getClass(clazz)
+    let selectors = ["shared", "sharedInstance", "instance", "sharedManager"]
+    for name in selectors {
+      let selector = NSSelectorFromString(name)
+      guard let metaClass, class_respondsToSelector(metaClass, selector) else { continue }
+      guard let method = class_getMethodImplementation(metaClass, selector) else { continue }
+      typealias Function = @convention(c) (AnyObject, Selector) -> AnyObject
+      let function = unsafeBitCast(method, to: Function.self)
+      return function(clazz, selector)
+    }
+    return nil
+  }
+
+  private static func resolveDevToDevClass(from candidates: [String]) -> AnyClass? {
+    for name in candidates {
+      if let clazz = NSClassFromString(name) {
+        return clazz
+      }
+    }
+    return nil
+  }
+
+  private static func invokeClassMethod(
+    _ metaClass: AnyClass?,
+    target: AnyObject,
+    candidates: [(String, (IMP, Selector) -> Void)]
+  ) -> Bool {
+    guard let metaClass else { return false }
+    for candidate in candidates {
+      let selector = NSSelectorFromString(candidate.0)
+      guard class_respondsToSelector(metaClass, selector) else { continue }
+      guard let method = class_getMethodImplementation(metaClass, selector) else { continue }
+      candidate.1(method, selector)
+      return true
+    }
+    return false
+  }
+
+  private static func invoke(target: AnyObject, candidates: [(String, (IMP, Selector) -> Void)]) -> Bool {
+    for candidate in candidates {
+      let selector = NSSelectorFromString(candidate.0)
+      guard target.responds(to: selector) else { continue }
+      let method = target.method(for: selector)
+      candidate.1(method, selector)
+      return true
+    }
+    return false
+  }
+
+  private static func invokeInstanceMethod(
+    _ instance: AnyObject,
+    candidates: [(String, (IMP, Selector) -> Void)]
+  ) -> Bool {
+    return invoke(target: instance, candidates: candidates)
   }
 }


### PR DESCRIPTION
## Summary
- add the official DevToDev analytics dependency and Maven repository to the Android build configuration
- harden the Android DevToDev method handler to locate multiple SDK entry points and report availability errors
- add the DevToDev CocoaPod and implement a runtime bridge on iOS that routes initialize/logEvent/setUserId calls

## Testing
- flutter test *(fails: flutter not installed in container)*
- pod install *(fails: pod command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ceb10b768483209aa84497254652e7